### PR TITLE
Fix #15 make this repository a module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pacifica/userinterface-core",
-    "description": "Drupal core profile for Pacifica user interfaces.",
-    "type": "drupal-profile",
+    "description": "Drupal core module for Pacifica user interfaces.",
+    "type": "drupal-module",
     "license": "LGPL-3.0-or-later",
     "authors": [
         {


### PR DESCRIPTION
This changes the repository type from profile to module so it will
install in the drupal modules directory.

Fix #15

Signed-off-by: David Brown <dmlb2000@gmail.com>