### PR TITLE
Fix #14 change the name to pacifica/pacifica

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pacifica/userinterface-core",
+    "name": "pacifica/pacifica",
     "description": "Drupal core module for Pacifica user interfaces.",
     "type": "drupal-module",
     "license": "LGPL-3.0-or-later",


### PR DESCRIPTION
The composer name pacifica-userinterface-core is too long, with
the changed scope of the repo it should be just pacifica/pacifica.

Fix #14

Signed-off-by: David Brown <dmlb2000@gmail.com>